### PR TITLE
Switch to ObjectCountCollector instead of ModelsCollector

### DIFF
--- a/collectors/ModelsCollector.php
+++ b/collectors/ModelsCollector.php
@@ -1,24 +1,17 @@
 <?php namespace Winter\Debugbar\Collectors;
 
-use Barryvdh\Debugbar\DataCollector\ModelsCollector as BaseModelsCollector;
-use Illuminate\Contracts\Events\Dispatcher;
+use DebugBar\DataCollector\ObjectCountCollector;
 use Winter\Storm\Database\Model;
 
-class ModelsCollector extends BaseModelsCollector
+class ModelsCollector extends ObjectCountCollector
 {
-    public $models = [];
-    public $count = 0;
-
-    /**
-     * @param Dispatcher $events
-     */
-    public function __construct(Dispatcher $events)
+    public function __construct()
     {
+        parent::__construct('models');
+
         Model::extend(function ($model) {
             $model->bindEvent('model.afterFetch', function () use ($model) {
-                $class = get_class($model);
-                $this->models[$class] = ($this->models[$class] ?? 0) + 1;
-                $this->count++;
+                $this->countClass($model);
             });
         });
     }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=7.0",
         "composer/installers": "~1.0",
-        "barryvdh/laravel-debugbar": "~3.0"
+        "barryvdh/laravel-debugbar": "^3.10.3"
     },
     "replace": {
         "rainlab/debugbar-plugin": ">=1.0.5"


### PR DESCRIPTION
`Barryvdh\Debugbar\DataCollector\ModelsCollector` will be removed in the future (https://github.com/barryvdh/laravel-debugbar/pull/1517)

They upstream to `DebugBar\DataCollector\ObjectCountCollector` 
[barryvdh/laravel-debugbar/src/LaravelDebugbar.php#L427-L432](https://github.com/barryvdh/laravel-debugbar/blob/d1a48965f2b25a6cec2eea07d719b568a37c9a88/src/LaravelDebugbar.php#L427-L432)
[maximebf/php-debugbar/src/DebugBar/DataCollector/ObjectCountCollector.php](https://github.com/maximebf/php-debugbar/blob/master/src/DebugBar/DataCollector/ObjectCountCollector.php)