### PR TITLE
Fix debugbar exception on ModelsCollector

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -115,6 +115,9 @@ class Plugin extends PluginBase
     public function addGlobalCollectors()
     {
         if (Config::get('debugbar.collectors.models', true)) {
+            // Disable original models collector because it will be replaced
+            Config::set('debugbar.collectors.models', false);
+
             /** @var \Barryvdh\Debugbar\LaravelDebugbar $debugBar */
             $debugBar = $this->app->make(\Barryvdh\Debugbar\LaravelDebugbar::class);
             $modelsCollector = $this->app->make(ModelsCollector::class);


### PR DESCRIPTION
There is a bug, tests it on latest laravel debugbar version, look `Exceptions` tab
![image](https://github.com/wintercms/wn-debugbar-plugin/assets/4933954/0f1f3f02-8e7e-4248-ba51-1cbbb64e31e5)